### PR TITLE
Rsync: Symlinks are synced as such.

### DIFF
--- a/lib/Provision/DSL/Entity/Rsync.pm
+++ b/lib/Provision/DSL/Entity/Rsync.pm
@@ -74,6 +74,7 @@ sub _run_rsync_command {
         '--recursive',
         '--perms',
         '--delete',
+        '--links',
         @_,
         $self->_exclude_list,
         "${\$self->content}/" => "${\$self->path}/",


### PR DESCRIPTION
Without this change, symlinks aren’t synced at all (rsync says „skipping non-regular file $file“).