### PR TITLE
Fix unit test and syncing of symlinks.

### DIFF
--- a/lib/Provision/DSL/Local/Cache.pm
+++ b/lib/Provision/DSL/Local/Cache.pm
@@ -145,6 +145,7 @@ sub _pack_file_or_dir {
         '--checksum',
         '--recursive',
         '--perms',
+        '--links',
         '--delete',
         ( map { ('--exclude' => $_) } @exclude ),
         $source => join('/', $self->dir, $target),

--- a/lib/Provision/DSL/Local/Proxy.pm
+++ b/lib/Provision/DSL/Local/Proxy.pm
@@ -78,6 +78,7 @@ sub pull_cache {
         '--checksum',
         '--recursive',
         '--perms',
+        '--links',
         '--delete',
         '--exclude', '"/lib/**.pod"',
         '--exclude', "/lib/perl5/$archname",

--- a/t/60_source/source_url.t
+++ b/t/60_source/source_url.t
@@ -11,8 +11,8 @@ my $ip = gethostbyname('www.cpan.org')
         exit;
     };
 
-my $u = Provision::DSL::Source::Url->new('http://www.cpan.org/');
-like $u->content, qr{<title>.*Comprehensive.*</title>}xms,
+my $u = Provision::DSL::Source::Url->new('http://perldoc.perl.org/');
+like $u->content, qr{<title>.*Perl.*</title>}xms,
      'html content looks good';
 
 done_testing;


### PR DESCRIPTION
Requesting http://www.cpan.org doesn’t work anymore, since they use HTTPs now. Switching to another Perl related page that still is available via non encrypted http.

Also: Syncing of symlinks needed to more adjustments.